### PR TITLE
Add JUnit Jupiter dependencies to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,9 +48,26 @@
         <maven-gpg-plugin>3.1.0</maven-gpg-plugin>
         <com-googlecode-libphonenumber>8.13.12</com-googlecode-libphonenumber>
         <jacoco-maven-plugin>0.8.11</jacoco-maven-plugin>
+        <junit-jupiter-api>5.10.0</junit-jupiter-api>
+        <junit-jupiter-engine>5.10.0</junit-jupiter-engine>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>${junit-jupiter-api}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>${junit-jupiter-engine}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
 
     <build>
         <plugins>


### PR DESCRIPTION
JUnit Jupiter dependencies have been added to the project's pom.xml file for unit testing purposes. These include junit-jupiter-api and junit-jupiter-engine, both set at version 5.10.0, and marked with a test scope, emphasizing their purpose for testing.