### PR TITLE
Add Mockito dependencies to pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
         <jacoco-maven-plugin>0.8.11</jacoco-maven-plugin>
         <junit-jupiter-api>5.10.0</junit-jupiter-api>
         <junit-jupiter-engine>5.10.0</junit-jupiter-engine>
+        <mockito-core>5.4.0</mockito-core>
+        <mockito-junit-jupiter>5.4.0</mockito-junit-jupiter>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
@@ -65,6 +67,18 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit-jupiter-engine}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockito-core}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Mockito dependencies have been added to the project's pom.xml file for mock testing purposes. These include mockito-core and mockito-junit-jupiter, both set at version 5.4.0 and specified within the test scope, thereby clearly indicating that they are specifically for testing.