### PR TITLE
Exclude interfaces in Jacoco configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -128,6 +128,11 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco-maven-plugin}</version>
+                <configuration>
+                    <excludes>
+                        <exclude>**/interfaces/**</exclude>
+                    </excludes>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
The configuration for the Jacoco Maven plugin in the pom.xml file has been modified. With this update, interfaces in the specified directory will be excluded during Jacoco's code coverage reporting.