### PR TITLE
Remove libphonenumber dependency from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,6 @@
         <maven-surefire-plugin>3.1.2</maven-surefire-plugin>
         <nexus-staging-maven-plugin>1.6.13</nexus-staging-maven-plugin>
         <maven-gpg-plugin>3.1.0</maven-gpg-plugin>
-        <com-googlecode-libphonenumber>8.13.12</com-googlecode-libphonenumber>
         <jacoco-maven-plugin>0.8.11</jacoco-maven-plugin>
         <junit-jupiter-api>5.10.0</junit-jupiter-api>
         <junit-jupiter-engine>5.10.0</junit-jupiter-engine>


### PR DESCRIPTION
Removed the com-googlecode-libphonenumber dependency from the project's pom.xml file. This specific dependency is no longer necessary for the project's build and runtime, hence has been removed to simplify the build process and limit the project's overall dependency footprint.